### PR TITLE
Implement domain guessing utility

### DIFF
--- a/tests/test_domain_guesser.py
+++ b/tests/test_domain_guesser.py
@@ -1,0 +1,17 @@
+import unittest
+
+from utils.domain_guesser import DomainGuesser
+
+
+class TestDomainGuesser(unittest.TestCase):
+    def setUp(self) -> None:
+        self.guesser = DomainGuesser()
+
+    def test_generate_candidates(self) -> None:
+        cands = self.guesser.generate_candidates("Example Fund")
+        self.assertIn("examplefund.com", cands)
+        self.assertIn("examplefund.org", cands)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -6,6 +6,7 @@ from .public_filings import PublicFilingsFinder, Filing, ContactInfo
 from .contact_identifier import ContactIdentifier, MatchedContact, Contact
 from .contact_integration import ContactIntegration, ContactRecord
 from .email_patterns import EmailPatternGenerator, EmailCandidate
+from .domain_guesser import DomainGuesser
 from .test_framework import TestFramework, Sample
 
 __all__ = [
@@ -25,6 +26,7 @@ __all__ = [
     "ContactRecord",
     "EmailPatternGenerator",
     "EmailCandidate",
+    "DomainGuesser",
     "TestFramework",
     "Sample",
 ]

--- a/utils/domain_guesser.py
+++ b/utils/domain_guesser.py
@@ -1,0 +1,51 @@
+import re
+import socket
+from typing import List, Optional
+
+try:
+    import requests  # type: ignore
+except Exception:  # pragma: no cover - fallback when requests not installed
+    requests = None
+
+
+class DomainGuesser:
+    """Guess possible domains for an organization name."""
+
+    COMMON_TLDS: List[str] = [".com", ".org", ".net", ".us"]
+
+    def __init__(self, tlds: Optional[List[str]] = None) -> None:
+        self.tlds = tlds or self.COMMON_TLDS
+
+    @staticmethod
+    def _normalize(name: str) -> str:
+        return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+    def generate_candidates(self, name: str) -> List[str]:
+        base = self._normalize(name)
+        if not base:
+            return []
+        candidates: List[str] = []
+        for tld in self.tlds:
+            candidates.append(f"{base}{tld}")
+        return candidates
+
+    def guess(self, name: str) -> Optional[str]:
+        for domain in self.generate_candidates(name):
+            if self._domain_exists(domain):
+                return domain
+        return None
+
+    def _domain_exists(self, domain: str) -> bool:
+        """Check whether a domain resolves or responds."""
+        try:
+            socket.gethostbyname(domain)
+        except Exception:
+            return False
+        if requests:
+            try:
+                resp = requests.head(f"https://{domain}", timeout=5)
+                if resp.status_code < 400:
+                    return True
+            except Exception:
+                pass
+        return True


### PR DESCRIPTION
## Summary
- add a `DomainGuesser` utility to guess potential domains from organization names
- expose `DomainGuesser` in `utils.__init__`
- add corresponding unit tests

## Testing
- `python -m unittest discover -v tests`